### PR TITLE
Add Jocelyne Firebase typing-logger prototype

### DIFF
--- a/prototypes/jocelyne-typing-logger/README.md
+++ b/prototypes/jocelyne-typing-logger/README.md
@@ -1,0 +1,31 @@
+# Jocelyne’s typing-test logging prototype
+
+This folder contains a standalone HTML/JS prototype for our pain typing study.
+
+## What it does
+
+- Signs participants in anonymously using Firebase Authentication.
+- Creates a session document per test under `users/{uid}/sessions`.
+- Logs:
+  - `start-button-pressed`
+  - typing focus / blur
+  - `typing-keydown` (including key, code, modifiers)
+  - `typing-input` (text length only, not full content)
+- Saves all events to:
+  - Local Storage (for export)
+  - Firestore under `users/{uid}/events`
+- Can export the full local event history as a `.json` file.
+
+## How to run locally
+
+1. Open this folder in a simple HTTP server, for example:
+
+   ```bash
+   cd prototypes/jocelyne-typing-logger
+   npx http-server .
+
+2.	Visit the shown URL (e.g. http://127.0.0.1:8080).
+3.	Enter a participant name, press Start typing, type in the textarea.	
+4.	Use “Export events as JSON” to download the keystroke log.
+
+This prototype is intended as a reference for integrating logging into the main React-based typing test.

--- a/prototypes/jocelyne-typing-logger/index.html
+++ b/prototypes/jocelyne-typing-logger/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Typing test – Firebase prototype</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="card">
+    <h1>Typing test</h1>
+    <p class="desc">Blah blah description of task… Click the button to begin.</p>
+
+    <!-- Participant name field -->
+    <p>
+      <label for="name">Participant name:</label>
+      <input id="name" class="name" placeholder="e.g., Bella" />
+    </p>
+
+    <button id="startBtn" class="cta">Start typing</button>
+
+    <!-- typing area for the test -->
+    <p>
+      <label for="typingArea">Typing area:</label><br/>
+      <textarea id="typingArea" rows="4" style="width:100%;" placeholder="Start typing here…"></textarea>
+    </p>
+
+    <!-- export button -->
+    <button id="exportBtn" class="cta">Export events as JSON</button>
+
+    <div id="log" class="log" aria-live="polite"></div>
+    <div id="status" class="status"></div>
+
+  </main>
+
+  <!-- Load ALL app JS from here -->
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/prototypes/jocelyne-typing-logger/main.js
+++ b/prototypes/jocelyne-typing-logger/main.js
@@ -1,0 +1,238 @@
+// ----- UI elements -----
+const startBtn   = document.getElementById('startBtn');
+const log        = document.getElementById('log');
+const typingArea = document.getElementById('typingArea');   // textarea
+const exportBtn  = document.getElementById('exportBtn');    // export button
+const nameEl     = document.getElementById('name');         // participant name input
+
+// ----- Status helper -----
+const statusEl = document.getElementById('status') || (() => {
+  const d = document.createElement('div');
+  d.id = 'status';
+  d.className = 'status';
+  d.style = 'margin-top:8px;font-size:12px;opacity:.8';
+  document.querySelector('.card')?.appendChild(d);
+  return d;
+})();
+const setStatus = (t) => { statusEl.textContent = t; console.log('[status]', t); };
+
+// ----- Participant name in localStorage -----
+const NAME_KEY = 'typingTest.participantName';
+if (nameEl) {
+  nameEl.value = localStorage.getItem(NAME_KEY) || '';
+  nameEl.addEventListener('input', () =>
+    localStorage.setItem(NAME_KEY, nameEl.value.trim())
+  );
+}
+
+// ----- local storage helpers for events -----
+const STORAGE_KEY = 'typingTest.events';
+const readEvents  = () => {
+  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]'); }
+  catch { return []; }
+};
+const writeEvents = (arr) =>
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(arr));
+const appendLine  = (t) => {
+  const time = new Date().toLocaleTimeString();
+  log.textContent = `[${time}] ${t}\n` + log.textContent;
+};
+
+// ----- Firebase (CDN ESM imports in a module) -----
+import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
+import { getAuth, signInAnonymously, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  serverTimestamp,
+  doc,
+  setDoc
+} from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
+
+// config (from Firebase)
+const firebaseConfig = {
+  apiKey: "AIzaSyBZMmEM6N8GtgNcvR9h7nm8vZ5r-D_L1-8",
+  authDomain: "pain-typing-test.firebaseapp.com",
+  projectId: "pain-typing-test",
+  storageBucket: "pain-typing-test.firebasestorage.app",
+  messagingSenderId: "710181767573",
+  appId: "1:710181767573:web:7eb05352c663027f3fce9c"
+};
+
+// ----- init Firebase -----
+let app, auth, db, uid = null;
+try {
+  app = initializeApp(firebaseConfig);
+  auth = getAuth(app);
+  db   = getFirestore(app);
+  setStatus("Firebase initialized");
+} catch (e) {
+  setStatus("Firebase init FAILED — check config");
+  console.error(e);
+}
+
+// ----- export helper -----
+// Download an array of events as a JSON file
+function downloadJson(filename, data) {
+  const blob = new Blob(
+    [JSON.stringify(data, null, 2)],
+    { type: 'application/json' }
+  );
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+// ----- session state and creator -----
+let currentSessionId = null;
+
+// create a session doc; events will reference sessionId
+function startSession() {
+  const localId = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  currentSessionId = localId;
+
+  if (uid && db) {
+    const meta = {
+      startedAt: new Date().toISOString(),
+      ts_server: serverTimestamp(),
+      participantName: nameEl?.value.trim() || null,
+      userAgent: navigator.userAgent,
+      viewport: { w: innerWidth, h: innerHeight }
+    };
+    addDoc(collection(db, 'users', uid, 'sessions'), meta)
+      .then(ref => {
+        currentSessionId = ref.id;              // prefer Firestore id
+        appendLine(`↳ session started id: ${ref.id}`);
+      })
+      .catch(err => appendLine(`↳ session create failed: ${err.message}`));
+  }
+}
+
+// ----- helper: upsert the user profile document -----
+async function saveUserProfile(uid, data) {
+  // merge:true = update or create if missing
+  await setDoc(doc(db, 'users', uid), data, { merge: true });
+}
+
+// ----- sign in (anonymous) -----
+if (auth) {
+  signInAnonymously(auth).catch(e => {
+    setStatus("Anon sign-in failed");
+    console.error(e);
+  });
+  onAuthStateChanged(auth, (user) => {
+    uid = user?.uid || null;
+    setStatus(uid ? `Signed in (anon) uid=${uid.slice(0,6)}…` : "Not signed in");
+  });
+}
+
+// ----- event recording -----
+async function recordEvent(type, extra = {}) {
+  const participantName = nameEl?.value.trim() || null;
+
+  const evt = {
+    type,
+    ts: Date.now(),
+    iso: new Date().toISOString(),
+    perf: performance.now(),
+    participantName,
+    sessionId: currentSessionId,
+    userAgent: navigator.userAgent,
+    viewport: { w: innerWidth, h: innerHeight },
+    ...extra
+  };
+
+  // local-first
+  const events = readEvents();
+  events.unshift(evt);
+  writeEvents(events);
+  appendLine(`${evt.type} at ${evt.iso} (local ok)`);
+  console.log('Recorded event:', evt);
+
+  // try online
+  try {
+    if (!uid || !db) throw new Error("No uid/db yet");
+
+    // make sure user profile exists / is updated
+    if (participantName) {
+      await saveUserProfile(uid, {
+        name: participantName,
+        updatedAt: serverTimestamp()
+      });
+    }
+
+    const ref = await addDoc(
+      collection(db, 'users', uid, 'events'),
+      { ...evt, ts_server: serverTimestamp() }
+    );
+    appendLine(`↳ saved online id: ${ref.id}`);
+  } catch (e) {
+    appendLine(`↳ online save failed: ${e.message}`);
+    console.warn(e);
+  }
+}
+
+// ----- extra event logging for typing area -----
+if (typingArea) {
+  // When user focuses the textarea
+  typingArea.addEventListener('focus', () => {
+    recordEvent('typing-focus');
+  });
+
+  // When user leaves the textarea
+  typingArea.addEventListener('blur', () => {
+    recordEvent('typing-blur');
+  });
+
+  // When user presses a key (we log which key)
+  typingArea.addEventListener('keydown', (e) => {
+    recordEvent('typing-keydown', {
+      key: e.key,
+      code: e.code,
+      ctrl: e.ctrlKey,
+      alt: e.altKey,
+      meta: e.metaKey,
+    });
+  });
+
+  // When the text content changes (we log length only, not full text)
+  typingArea.addEventListener('input', (e) => {
+    recordEvent('typing-input', {
+      length: e.target.value.length
+    });
+  });
+}
+
+// ----- show last event on load -----
+const prev = readEvents()[0];
+if (prev) appendLine(`Last event: ${prev.type} at ${prev.iso}`);
+
+// ----- wire buttons -----
+startBtn.addEventListener('click', async () => {
+  if (!currentSessionId) startSession();
+  await recordEvent('start-button-pressed');
+});
+
+if (exportBtn) {
+  exportBtn.addEventListener('click', () => {
+    const events = readEvents();
+    if (!events.length) {
+      appendLine('No events to export yet.');
+      return;
+    }
+
+    const filename = `typing-events-${new Date()
+      .toISOString()
+      .slice(0, 19)
+      .replace(/[:T]/g, '-')}.json`;
+
+    downloadJson(filename, events);
+    appendLine(`Exported ${events.length} events to ${filename}`);
+  });
+}

--- a/prototypes/jocelyne-typing-logger/style.css
+++ b/prototypes/jocelyne-typing-logger/style.css
@@ -1,0 +1,10 @@
+:root { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+body { margin: 0; background:#f7f7fb; display:grid; place-items:center; min-height:100dvh; }
+.card { background:#fff; padding:24px; border-radius:16px; width:min(680px,92vw); box-shadow:0 6px 30px rgba(0,0,0,.08); }
+h1 { margin:0 0 8px; }
+.desc { color:#444; margin:0 0 20px; }
+.cta { padding:14px 18px; border-radius:12px; border:0; font-weight:600; cursor:pointer; }
+.cta:active { transform: translateY(1px); }
+.log { margin-top:18px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+       background:#fafafa; border:1px solid #eee; padding:12px; border-radius:10px; white-space:pre-wrap; }
+.status { margin-top:10px; font-size:12px; opacity:.75; }


### PR DESCRIPTION
This adds a small typing test prototype that logs typing events (keydown, input length, focus and blur) to Firestore using anonymous sign-in.
It also includes a button to export all events as a JSON file.

This is mainly so we can look at how the logging works and then decide how to add it into the main React app later.
The files are only in prototypes/jocelyne-typing-logger/, so nothing in the main project is changed. :)